### PR TITLE
Pass extra args on hooks-run-hook

### DIFF
--- a/zsh-hooks.plugin.zsh
+++ b/zsh-hooks.plugin.zsh
@@ -92,7 +92,7 @@ hooks-add-hook(){
 
 hooks-run-hook(){
   for f in ${(P)1}; do
-    $f
+    $f ${@:2} # send given args to the func
   done
 }
 


### PR DESCRIPTION
Hi, great plugin! :smiley: 

I recently needed to pass arguments to the hooks (e.g: the `preexec` zsh hook has 3 args).
Here is my take on the problem, might be helpful for others too!